### PR TITLE
add Procfile for heroku deploy

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+kyaru: bundle exec ruby kyaru.rb


### PR DESCRIPTION
#2 関連
Heroku上でbotのプロセスを動かすために`Procfile`なるものを追加する必要があるらしい