### PR TITLE
herokuのpostgresqlをつかって所持金の概念を実装する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'discordrb'
 gem 'sequel'
+gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -23,6 +23,7 @@ GEM
     netrc (0.11.0)
     opus-ruby (1.0.1)
       ffi
+    pg (1.1.4-x64-mingw32)
     rbnacl (3.4.0)
       ffi
     rest-client (2.1.0-x64-mingw32)
@@ -45,6 +46,7 @@ PLATFORMS
 
 DEPENDENCIES
   discordrb
+  pg
   sequel
 
 BUNDLED WITH

--- a/kyaru.rb
+++ b/kyaru.rb
@@ -33,7 +33,7 @@ bot.message(with_text: 'money') do |event|
   event.respond money.amount.to_s
 end
 
-# money という発言があったらそのチャンネルで キャルの現在の所持金 を発言する
+# money+100 という発言があったらそのチャンネルで キャルの現在の所持金に100足した数 を発言する
 bot.message(with_text: 'money+100') do |event|
   money = Money[1]
   money.set(:amount => money.amount+100)

--- a/kyaru.rb
+++ b/kyaru.rb
@@ -20,14 +20,9 @@ bot = Discordrb::Bot.new token: discord_token
 db  = Sequel.connect postgres_url
 
 # キャルの所持金を定義する
-db.create_table :money do
-  primary_key   :id
-  # 所持金
-  Integer       :amount
-end
 class Money < Sequel::Model; end
 money = Money[1]
-unless money?
+unless money
   money = Money.new(:amount => 0)
   money.save
 end
@@ -35,6 +30,14 @@ end
 # money という発言があったらそのチャンネルで キャルの現在の所持金 を発言する
 bot.message(with_text: 'money') do |event|
   money = Money[1]
+  event.respond money.amount.to_s
+end
+
+# money という発言があったらそのチャンネルで キャルの現在の所持金 を発言する
+bot.message(with_text: 'money+100') do |event|
+  money = Money[1]
+  money.set(:amount => money.amount+100)
+  money.save
   event.respond money.amount.to_s
 end
 

--- a/kyaru.rb
+++ b/kyaru.rb
@@ -56,6 +56,11 @@ bot.message(with_text: 'neko') do |event|
   event.respond 'あたしの下僕にしてあげよっか……♪'
 end
 
+# oide という発言があったらそのチャンネルで ちょっとはなれてよ... と発言する
+bot.message(with_text: 'oide') do |event|
+  event.respond 'ちょっ、はなれてよ殺すわよっ！？'
+end
+
 # 定期的な処理をする部分
 previous = Time.new
 bot.heartbeat do |event|
@@ -67,10 +72,6 @@ bot.heartbeat do |event|
   end
 end
 
-# oide という発言があったらそのチャンネルで ちょっとはなれてよ... と発言する
-bot.message(with_text: 'oide') do |event|
-  event.respond 'ちょっ、はなれてよ殺すわよっ！？'
-end
 
 bot.run
 


### PR DESCRIPTION
fix #27 

herokuのpostgresqlにキャルの所持金の値を保存する

`money`という発言で所持金を確認する
`mone+100`という発言で所持金を+100する