### PR TITLE
Kyaru::Message の追加

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,6 +13,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     event_emitter (0.2.6)
+    ffi (1.11.1)
     ffi (1.11.1-x64-mingw32)
     http-accept (1.7.0)
     http-cookie (1.0.3)
@@ -23,9 +24,15 @@ GEM
     netrc (0.11.0)
     opus-ruby (1.0.1)
       ffi
+    pg (1.1.4)
     pg (1.1.4-x64-mingw32)
     rbnacl (3.4.0)
       ffi
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rest-client (2.1.0-x64-mingw32)
       ffi (~> 1.9)
       http-accept (>= 1.7.0, < 2.0)
@@ -42,6 +49,7 @@ GEM
       websocket
 
 PLATFORMS
+  ruby
   x64-mingw32
 
 DEPENDENCIES

--- a/kyaru.rb
+++ b/kyaru.rb
@@ -145,4 +145,10 @@ bot.heartbeat do |event|
   end
 end
 
+# Kyaru::Message
+# 定型文の実装をアダプターパターンで押し込める
+require_relative 'lib/kyaru'
+message = Kyaru::Message.new(bot)
+message.apply
+
 bot.run

--- a/lib/kyaru.rb
+++ b/lib/kyaru.rb
@@ -1,0 +1,7 @@
+
+module Kyaru
+end
+
+require_relative './kyaru/version'
+require_relative './kyaru/message'
+

--- a/lib/kyaru/message.rb
+++ b/lib/kyaru/message.rb
@@ -1,0 +1,17 @@
+
+class Kyaru::Message
+  def initialize(bot)
+    @bot = bot
+  end
+
+  def apply
+    message
+  end
+
+  def message
+    @bot.message(with_text: /Kyaru::Message/) do |event|
+      event.respond 'Kyaru::Message'
+    end
+  end
+end
+

--- a/lib/kyaru/version.rb
+++ b/lib/kyaru/version.rb
@@ -1,0 +1,3 @@
+module Kyaru
+  VERSION = "0.1.0"
+end


### PR DESCRIPTION
定型文の実装とかする部分を分けた。
単純なものはこっちに移して見通しをよくする目的ですね。